### PR TITLE
Fix issue with unregistered Cassandra contact points

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,14 +3,15 @@ organization in ThisBuild := "sample.octanner"
 lazy val userApi = project("user-api")
    .settings(
      version := "1.0-SNAPSHOT",
-     libraryDependencies ++= Seq(lagomJavadslApi, lagomJavadslPersistence)
+     libraryDependencies += lagomJavadslApi
    )
   .dependsOn(imageApi)
 
 lazy val userImpl = project("user-impl")
    .enablePlugins(LagomJava)
    .settings(
-     version := "1.0-SNAPSHOT"
+     version := "1.0-SNAPSHOT",
+     libraryDependencies += lagomJavadslPersistence
    )
   .dependsOn(userApi, utils, imageApi)
 


### PR DESCRIPTION
I still have to pinpoint the exact problem, but the `lagomJavadslPersistence` dependency should be added to the implementation project, not the api. Having said that, there is definitely a bug on the Lagom side, so I'll make sure to open a ticket soon.
